### PR TITLE
Add 'status' enum to Jobs table & update to Job model.

### DIFF
--- a/migrations/20220421000635-add_status_to_jobs.js
+++ b/migrations/20220421000635-add_status_to_jobs.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          "Jobs",
+          "status",
+          {
+            allowNull: false,
+            type: Sequelize.ENUM("Applied", "Interview Scheduled", "Decision Pending", "Accepted", "Rejected"),
+            defaultValue: "Applied",
+          },
+          {
+            transaction: t,
+          }
+        ),
+      ]);
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    return queryInterface.removeColumn("Jobs", "status");
+  }
+};

--- a/models/job.js
+++ b/models/job.js
@@ -14,11 +14,28 @@ module.exports = (sequelize, DataTypes) => {
     }
   }
   Job.init({
-    internship: DataTypes.BOOLEAN,
-    title: DataTypes.STRING,
-    company: DataTypes.STRING,
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    company: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
     description: DataTypes.TEXT,
-    link: DataTypes.TEXT
+    internship: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    link: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM("Applied", "Interview Scheduled", "Decision Pending", "Accepted", "Rejected"),
+      defaultValue: "Applied",
+    },
   }, {
     sequelize,
     modelName: 'Job',


### PR DESCRIPTION
### What this PR does
------------------------

- This PR adds a migration to add a 'status' column to the Jobs table. Status is an enum represented by the following values: "Applied", "Interview Scheduled", "Decision Pending", "Accepted", and "Rejected".
- The default value for 'status' is "Applied"

### Getting Started
---------------------
1. Run `npx sequelize-cli db:migrate`
2. Navigate to adminer at http://localhost:8080 - Go to the Jobs table and check for the 'status' column
![Jobs Table - Status](https://user-images.githubusercontent.com/19893639/164350571-3f6e1fd8-892d-4ba8-ae2e-bef384d3b9d5.JPG)

