### PR TITLE
'Status' to Jobs table; Updates to 'Title' and 'Company' in Jobs table

### DIFF
--- a/migrations/20220421000635-add_status_to_jobs.js
+++ b/migrations/20220421000635-add_status_to_jobs.js
@@ -16,11 +16,59 @@ module.exports = {
             transaction: t,
           }
         ),
+        queryInterface.changeColumn(
+          "Jobs", 
+          "title", 
+          {
+            type: Sequelize.STRING,
+            allowNull: false
+          },
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.changeColumn(
+          "Jobs",
+          "company",
+          {
+            type: Sequelize.STRING,
+            allowNull: false,
+          },
+          {
+            transaction: t,
+          }
+        ),
       ]);
     });
   },
 
   async down (queryInterface, Sequelize) {
-    return queryInterface.removeColumn("Jobs", "status");
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn("Jobs", "status", {transaction: t}),
+        queryInterface.changeColumn(
+          "Jobs",
+          "title",
+          {
+            type: Sequelize.STRING,
+            allowNull: true 
+          }, 
+          {
+            transaction: t
+          }
+        ),
+        queryInterface.changeColumn(
+          "Jobs",
+          "company",
+          {
+            type: Sequelize.STRING,
+            allowNull: true 
+          }, 
+          {
+            transaction: t
+          }
+        ),
+      ]);
+    });
   }
 };

--- a/models/job.js
+++ b/models/job.js
@@ -4,11 +4,6 @@ const {
 } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
   class Job extends Model {
-    /**
-     * Helper method for defining associations.
-     * This method is not a part of Sequelize lifecycle.
-     * The `models/index` file will call this method automatically.
-     */
     static associate(models) {
       // define association here
     }
@@ -30,7 +25,6 @@ module.exports = (sequelize, DataTypes) => {
     },
     link: {
       type: DataTypes.TEXT,
-      allowNull: false
     },
     status: {
       type: DataTypes.ENUM("Applied", "Interview Scheduled", "Decision Pending", "Accepted", "Rejected"),


### PR DESCRIPTION
### What this PR does
-------------------

- This PR adds a migration to add a 'status' column to the Jobs table. Status is an enum represented by the following values: "Applied", "Interview Scheduled", "Decision Pending", "Accepted", and "Rejected".
- The default value for 'status' is "Applied"
- Both "title" and "company" attributes no longer allowNull

### Getting Started
---------------------

1. Run `npx sequelize-cli db:migrate`
2. Navigate to adminer at http://localhost:8080/ - Go to the Jobs table and check the 'status' column (new), and the changes to the 'title', and 'company' columns.
![Jobs Table](https://user-images.githubusercontent.com/19893639/164959736-83f3f102-df33-43b7-8834-9689d668810a.JPG)

