### PR TITLE
Added 'status' ENUM to Jobs table; updated attributes 'title' and 'co…

### DIFF
--- a/migrations/20220424063532-add-status-to-jobs-table.js
+++ b/migrations/20220424063532-add-status-to-jobs-table.js
@@ -1,0 +1,74 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          "Jobs",
+          "status",
+          {
+            allowNull: false,
+            type: Sequelize.ENUM("Applied", "Interview Scheduled", "Decision Pending", "Accepted", "Rejected"),
+            defaultValue: "Applied",
+          },
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.changeColumn(
+          "Jobs", 
+          "title", 
+          {
+            type: Sequelize.STRING,
+            allowNull: false
+          },
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.changeColumn(
+          "Jobs",
+          "company",
+          {
+            type: Sequelize.STRING,
+            allowNull: false,
+          },
+          {
+            transaction: t,
+          }
+        ),
+      ]);
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn("Jobs", "status", {transaction: t}),
+        queryInterface.changeColumn(
+          "Jobs",
+          "title",
+          {
+            type: Sequelize.STRING,
+            allowNull: true 
+          }, 
+          {
+            transaction: t
+          }
+        ),
+        queryInterface.changeColumn(
+          "Jobs",
+          "company",
+          {
+            type: Sequelize.STRING,
+            allowNull: true 
+          }, 
+          {
+            transaction: t
+          }
+        ),
+      ]);
+    });
+  }
+};

--- a/models/job.js
+++ b/models/job.js
@@ -14,12 +14,26 @@ module.exports = (sequelize, DataTypes) => {
   }
   Job.init(
     {
-      internship: DataTypes.BOOLEAN,
-      title: DataTypes.STRING,
-      company: DataTypes.STRING,
+      internship: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: false,
+      },
+      title: {
+          type: DataTypes.STRING,
+          allowNull: false
+      },
+      company: {
+          type: DataTypes.STRING,
+          allowNull: false
+      },
       description: DataTypes.TEXT,
       link: DataTypes.TEXT,
       userId: DataTypes.UUID,
+      status: {
+          type: DataTypes.ENUM("Applied", "Interview Scheduled", "Decision Pending", "Accepted", "Rejected"),
+          defaultValue: "Applied"
+      }
     },
     {
       sequelize,


### PR DESCRIPTION
### What this PR does
-------------

- This PR adds a migration to add a 'status' column to the Jobs table. Status is an enum represented by the following values: "Applied", "Interview Scheduled", "Decision Pending", "Accepted", and "Rejected".
- The default value for 'status' is "Applied"
- Both "title" and "company" attributes no longer allowNull
- Job Model is updated to reflect these changes.

### Getting Started
----------------

1. Run `npx sequelize-cli db:migrate`
2. Navigate to adminer at http://localhost:8080/ - Go to the Jobs table and check the 'status' column (new), and the changes to the 'title', and 'company' columns.
