### PR TITLE
Update skills table

### DIFF
--- a/migrations/20220422225015-modify-skills.js
+++ b/migrations/20220422225015-modify-skills.js
@@ -1,0 +1,37 @@
+"use strict";
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn("Skills", "desc", { transaction: t }),
+        queryInterface.addColumn(
+          "Skills",
+          "userId",
+          {
+            type: Sequelize.UUID,
+            references: {
+              model: { tableName: "Users" },
+              key: "id",
+            },
+            onDelete: "cascade",
+            allowNull: false,
+          },
+          {
+            transaction: t,
+          }
+        ),
+      ]);
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn("Skills", "desc", {
+          type: Sequelize.STRING,
+        }),
+        queryInterface.removeColumn("Skills", "userId"),
+      ]);
+    });
+  },
+};


### PR DESCRIPTION
This PR updates the skills table to add a userId, tying a particular skill to a user. 
Skills can be tied to a user via the UserSkills table in #21
Skills can be tied to a job via the JobSkills table in #22
