### PR TITLE
Add UserSkills migration

### DIFF
--- a/migrations/20220425183947-create-user-skills.js
+++ b/migrations/20220425183947-create-user-skills.js
@@ -1,0 +1,42 @@
+"use strict";
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("UserSkills", {
+      skillId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: { tableName: "Skills" },
+          key: "id",
+        },
+        onDelete: "cascade",
+        allowNull: false,
+      },
+      userId: {
+        type: Sequelize.UUID,
+        references: {
+          model: { tableName: "Users" },
+          key: "id",
+        },
+        onDelete: "cascade",
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    }).then(() => {
+      return queryInterface.addConstraint('UserSkills', {
+        fields: ['skillId', 'userId'],
+        type: 'primary key',
+        name: 'UserSkills_pkey'
+      })
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("UserSkills");
+  },
+};

--- a/models/userskills.js
+++ b/models/userskills.js
@@ -1,0 +1,26 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, DataTypes) => {
+  class UserSkills extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+      // TODO:
+    }
+  }
+  UserSkills.init(
+    {
+      skillId: { type: DataTypes.INTEGER, primaryKey: true },
+      userId: { type: DataTypes.UUID, primaryKey: true },
+    },
+    {
+      sequelize,
+      modelName: "UserSkills",
+    }
+  );
+  return UserSkills;
+};


### PR DESCRIPTION
This PR adds a UserSkills table.
It references a user row and a skills row as a composite primary key.

The model associations and any seeds will be added in a follow up PR.