### PR TITLE
Add associations job -> skills

### DIFF
--- a/middlewares/requireAuth.middleware.js
+++ b/middlewares/requireAuth.middleware.js
@@ -7,7 +7,7 @@ module.exports = async (req, res, next) => {
     if (!user) {
       res.status(401).send();
     }
-    req.user = user;
+    req.user = user.dataValues;
     next();
   } catch (error) {
     console.error(error);

--- a/models/job.js
+++ b/models/job.js
@@ -10,30 +10,48 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       // define association here
       this.belongsTo(models.User, { foreignKey: "userId" });
+      this.hasMany(models.JobSkills, {
+        foreignKey: "jobId",
+        as: "skills",
+      });
+
     }
   }
   Job.init(
     {
       internship: {
-          type: DataTypes.BOOLEAN,
-          allowNull: false,
-          defaultValue: false,
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
       },
       title: {
-          type: DataTypes.STRING,
-          allowNull: false
+        type: DataTypes.STRING,
+        allowNull: false,
       },
       company: {
-          type: DataTypes.STRING,
-          allowNull: false
+        type: DataTypes.STRING,
+        allowNull: false,
       },
       description: DataTypes.TEXT,
       link: DataTypes.TEXT,
-      userId: DataTypes.UUID,
+      userId: {
+        type: DataTypes.UUID,
+        references: {
+          model: "Users",
+          key: "id",
+        },
+        allowNull: false,
+      },
       status: {
-          type: DataTypes.ENUM("Applied", "Interview Scheduled", "Decision Pending", "Accepted", "Rejected"),
-          defaultValue: "Applied"
-      }
+        type: DataTypes.ENUM(
+          "Applied",
+          "Interview Scheduled",
+          "Decision Pending",
+          "Accepted",
+          "Rejected"
+        ),
+        defaultValue: "Applied",
+      },
     },
     {
       sequelize,

--- a/models/jobskills.js
+++ b/models/jobskills.js
@@ -1,7 +1,5 @@
-'use strict';
-const {
-  Model
-} = require('sequelize');
+"use strict";
+const { Model } = require("sequelize");
 module.exports = (sequelize, DataTypes) => {
   class JobSkills extends Model {
     /**
@@ -10,15 +8,25 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      this.belongsTo(models.Job, {
+        foreignKey: "jobId",
+        as: "job",
+      });
+      this.belongsTo(models.Skill, {
+        foreignKey: "skillId",
+        as: "skill",
+      });
     }
   }
-  JobSkills.init({
-    skillId: { type: DataTypes.INTEGER, primaryKey: true },
-    jobId: { type: DataTypes.INTEGER, primaryKey: true }
-  }, {
-    sequelize,
-    modelName: 'JobSkills',
-  });
+  JobSkills.init(
+    {
+      skillId: { type: DataTypes.INTEGER, primaryKey: true, references: { model: "Skills", key: "id" } },
+      jobId: { type: DataTypes.INTEGER, primaryKey: true, references: { model: "Jobs", key: "id" } },
+    },
+    {
+      sequelize,
+      modelName: "JobSkills",
+    }
+  );
   return JobSkills;
 };

--- a/models/skill.js
+++ b/models/skill.js
@@ -1,7 +1,5 @@
-'use strict';
-const {
-  Model
-} = require('sequelize');
+"use strict";
+const { Model } = require("sequelize");
 module.exports = (sequelize, DataTypes) => {
   class Skill extends Model {
     /**
@@ -13,13 +11,22 @@ module.exports = (sequelize, DataTypes) => {
       // define association here
     }
   }
-  Skill.init({
-    name: DataTypes.STRING,
-    desc: DataTypes.STRING
-  }, {
-    sequelize,
-    modelName: 'Skill',
-    timestamps: true,
-  });
+  Skill.init(
+    {
+      name: DataTypes.STRING,
+      userId: {
+        type: DataTypes.UUID,
+        references: {
+          model: "Users",
+          key: "id",
+        },
+      },
+    },
+    {
+      sequelize,
+      modelName: "Skill",
+      timestamps: true,
+    }
+  );
   return Skill;
 };

--- a/models/userskills.js
+++ b/models/userskills.js
@@ -9,7 +9,14 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      // TODO:
+      this.belongsTo(models.User, {
+        primaryKey: "userId",
+        as: "user"
+      });
+      this.belongsTo(models.Skill, {
+        primaryKey: "skillId",
+        as: "skill"
+      });
     }
   }
   UserSkills.init(

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -1,19 +1,34 @@
 const express = require("express");
 const router = express.Router();
+const { Job, Skill, JobSkills } = require("../models");
+const requireAuth = require("../middlewares/requireAuth.middleware");
 
-router.get("/", (_, res) => {
-  res.json([
-    {
-      id: 1,
-      job_title: "Software Developer",
-      skills: ["React", "NodeJs", "Sass"],
-    },
-    {
-      id: 2,
-      job_title: "QA Engineer",
-      skills: ["Testing", "Cypress", "Testcafe", "Jest"],
-    },
-  ]);
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const user = req.user;
+
+    const jobs = await Job.findAll({
+      where: {
+        userId: user.id,
+      },
+      include: [
+        {
+          model: JobSkills,
+          as: "skills",
+          include: [
+            {
+              model: Skill,
+              as: "skill",
+            }
+          ]
+        },
+      ],
+    });
+    
+    res.send(jobs);
+  } catch (error) {
+    res.status(500).send(error);
+  }
 });
 
 router.use("/jobs", router);


### PR DESCRIPTION
## What this PR does

- Sets up the associaiton between jobs and skills so we can get skills associated to a job.
- Also adds an endpoint `/api/jobs` which retrieves jobs and associated skills.
- Minor update in requireAuth middleware to fetch user from `dataValues`

## How
- Adds associations in models
- Adds query to get jobs for a user
- Updates requireAuth middleware

Example response:

<img width="937" alt="Screen Shot 2022-05-07 at 1 42 13 PM" src="https://user-images.githubusercontent.com/62804095/167265672-0d8041b1-3c18-41e8-9bad-a6af8cead1f6.png">
