### PR TITLE
Delete job modal

### DIFF
--- a/client/src/common/DeleteModal.tsx
+++ b/client/src/common/DeleteModal.tsx
@@ -33,7 +33,7 @@ export const DeleteModal: React.FunctionComponent<{
         </Grid>
         <Grid item xs={4}>
           <Button variant="contained" onClick={closeModal}>
-            Back
+            Cancel
           </Button>
         </Grid>
         <Grid item xs={4}>

--- a/client/src/pages/ContactsHome.tsx
+++ b/client/src/pages/ContactsHome.tsx
@@ -45,7 +45,7 @@ export const ContactsHome = () => {
                     <TableCell align="left">{row.phoneNumber}</TableCell>
                     <TableCell align="left">{row.company}</TableCell>
                     <TableCell align="left">
-                      <Link to="/contacts/view/${row.id}" style={{ textDecoration: 'none' }}>
+                      <Link to={`/contacts/view/${row.id}`} style={{ textDecoration: 'none' }}>
                         <Button variant="contained">View</Button>
                       </Link>
                     </TableCell>

--- a/client/src/pages/ContactsView.tsx
+++ b/client/src/pages/ContactsView.tsx
@@ -48,7 +48,7 @@ export const ContactsView = () => {
                 </Link>
               </Grid>
               <Grid item xs={4}>
-                <Link to="/contacts/edit/${row.id}" style={{ textDecoration: 'none' }}>
+                <Link to={`/contacts/edit/${fakeContact.id}`} style={{ textDecoration: 'none' }}>
                   <Button variant="contained">Edit</Button>
                 </Link>
               </Grid>

--- a/client/src/pages/jobPages/ViewJob.tsx
+++ b/client/src/pages/jobPages/ViewJob.tsx
@@ -1,16 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
-import { Typography, Chip, Container, Stack, Paper } from '@mui/material';
-import { useParams } from 'react-router-dom';
+import { Button, Typography, Chip, Container, Stack, Paper, Grid } from '@mui/material';
+import { useParams, useNavigate } from 'react-router-dom';
 import { StatusBar } from './StatusBar';
 import type { JobData, Skill } from '../../types';
+import { DeleteModal } from '../../common/DeleteModal';
 
 export const ViewJob = () => {
   const [jobData, setJobData] = useState<JobData | undefined>(undefined);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
   const { jobId } = useParams() as { jobId: string };
+  const navigate = useNavigate();
+
+  const toggleModal = useCallback(() => {
+    setModalIsOpen(!modalIsOpen);
+  }, [modalIsOpen]);
 
   // TODO: Remove after API call
   const tempSuperFakeNotRealJob = {
+    id: jobId,
     title: 'CTO',
     company: 'FakeBlock',
     description:
@@ -23,7 +32,6 @@ export const ViewJob = () => {
   useEffect(() => {
     setJobData({
       ...tempSuperFakeNotRealJob,
-      id: jobId,
       skills: [
         {
           id: '12345',
@@ -43,6 +51,12 @@ export const ViewJob = () => {
       },
     });
   }, []);
+
+  const deleteJob = useCallback(() => {
+    // TODO: Call delete job API
+    console.log(`Simulating delete job ${jobId}`);
+    navigate('/');
+  }, [jobId]);
 
   // Show loading state
   if (!jobData) {
@@ -116,6 +130,21 @@ export const ViewJob = () => {
           ) : (
             <p>There is no contact information for this job</p>
           )}
+          <Grid container direction="row" justifyContent="space-evenly">
+            <Button variant="contained" onClick={() => console.log('todo')}>
+              Edit Job
+            </Button>
+            <Button variant="contained" color="error" onClick={toggleModal}>
+              Delete Job
+            </Button>
+          </Grid>
+          <DeleteModal
+            open={modalIsOpen}
+            headingText="Are you sure?"
+            message={`Are you sure you want to delete ${jobData.title} at ${jobData.company}?  This is permenant.`}
+            deleteById={deleteJob}
+            closeModal={toggleModal}
+          />
         </Stack>
       </Paper>
     </Container>


### PR DESCRIPTION
This PR creates a reusable modal for deleting entities.  We can pass in the specific delete API that we want the modal to handle.  For consistency I ported it from the delete contact modal so they look and behave the same now.

![image](https://user-images.githubusercontent.com/55878920/167997839-e6e84f6c-b8f7-47ae-b232-d6a0404f8c29.png)
