### PR TITLE
Edit Job Page UI - Second Draft

### DIFF
--- a/client/src/common/ContactsUpdate.tsx
+++ b/client/src/common/ContactsUpdate.tsx
@@ -5,13 +5,18 @@ import { Link } from 'react-router-dom';
 interface ContactsProps {
   title: string;
   route: string;
+  contactData: ContactRowData;
 }
 
 export const ContactsUpdate = (props: ContactsProps) => {
-  const [contactName, setContactName] = useState<string>('');
-  const [contactEmail, setContactEmail] = useState<string>('');
-  const [contactPhoneNumber, setContactPhoneNumber] = useState<string>('');
-  const [contactCompany, setContactCompany] = useState<string>('');
+  const [contactName, setContactName] = useState<string>(props.contactData.name ? props.contactData.name : '');
+  const [contactEmail, setContactEmail] = useState<string>(props.contactData.email ? props.contactData.email : '');
+  const [contactPhoneNumber, setContactPhoneNumber] = useState<string>(
+    props.contactData.phone_no ? props.contactData.phone_no : '',
+  );
+  const [contactCompany, setContactCompany] = useState<string>(
+    props.contactData.company ? props.contactData.company : '',
+  );
 
   const handleContactNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setContactName(event.target.value);
@@ -52,6 +57,7 @@ export const ContactsUpdate = (props: ContactsProps) => {
                   variant="standard"
                   fullWidth
                   type="text"
+                  value={contactName}
                   onChange={handleContactNameChange}
                 />
               </Grid>
@@ -62,6 +68,7 @@ export const ContactsUpdate = (props: ContactsProps) => {
                   variant="standard"
                   fullWidth
                   type="text"
+                  value={contactEmail}
                   onChange={handleContactEmailChange}
                 />
               </Grid>
@@ -72,6 +79,7 @@ export const ContactsUpdate = (props: ContactsProps) => {
                   variant="standard"
                   fullWidth
                   type="text"
+                  value={contactPhoneNumber}
                   onChange={handleContactPhoneNoChange}
                 />
               </Grid>
@@ -82,6 +90,7 @@ export const ContactsUpdate = (props: ContactsProps) => {
                   variant="standard"
                   fullWidth
                   type="text"
+                  value={contactCompany}
                   onChange={handleContactCompanyChange}
                 />
               </Grid>
@@ -102,4 +111,11 @@ export const ContactsUpdate = (props: ContactsProps) => {
       </Paper>
     </Container>
   );
+};
+
+export type ContactRowData = {
+  name: string;
+  email: string;
+  phone_no: string;
+  company: string;
 };

--- a/client/src/common/Routes.tsx
+++ b/client/src/common/Routes.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 
 import { Login } from '../pages/Login';
 import { Signup } from '../pages/Signup';
-import { Home, CreateJob, ViewJob } from '../pages/jobPages';
+import { Home, CreateJob, ViewJob, EditJob } from '../pages/jobPages';
 import { CreateContact } from '../pages/CreateContact';
 import { ContactsHome } from '../pages/ContactsHome';
 import { ContactsView } from '../pages/ContactsView';
@@ -51,6 +51,14 @@ export const PageRoutes = () => {
         element={
           <PrivateRoute>
             <ViewJob />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/jobs/edit/:jobId"
+        element={
+          <PrivateRoute>
+            <EditJob />
           </PrivateRoute>
         }
       />

--- a/client/src/pages/ContactsEdit.tsx
+++ b/client/src/pages/ContactsEdit.tsx
@@ -1,4 +1,10 @@
-import { ContactsUpdate } from '../common/ContactsUpdate';
+import { ContactsUpdate, ContactRowData } from '../common/ContactsUpdate';
 export const ContactsEdit = () => {
-  return <ContactsUpdate title="Edit Contact" route="/contacts/view/:id" />;
+  const contactData: ContactRowData = {
+    name: '',
+    email: '',
+    phone_no: '',
+    company: '',
+  };
+  return <ContactsUpdate title="Edit Contact" route="/contacts/view/:id" contactData={contactData} />;
 };

--- a/client/src/pages/CreateContact.tsx
+++ b/client/src/pages/CreateContact.tsx
@@ -1,4 +1,10 @@
-import { ContactsUpdate } from '../common/ContactsUpdate';
+import { ContactsUpdate, ContactRowData } from '../common/ContactsUpdate';
 export const CreateContact = () => {
-  return <ContactsUpdate title="Create Contact" route="/contacts" />;
+  const contactData: ContactRowData = {
+    name: '',
+    email: '',
+    phone_no: '',
+    company: '',
+  };
+  return <ContactsUpdate title="Create Contact" route="/contacts" contactData={contactData} />;
 };

--- a/client/src/pages/jobPages/EditJob.tsx
+++ b/client/src/pages/jobPages/EditJob.tsx
@@ -1,0 +1,216 @@
+import {
+  Container,
+  Paper,
+  Stack,
+  Typography,
+  Box,
+  Grid,
+  TextField,
+  FormControlLabel,
+  Checkbox,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  SelectChangeEvent,
+  Button,
+} from '@mui/material';
+import { useState } from 'react';
+import { ContactsUpdate, ContactRowData } from '../../common/ContactsUpdate';
+
+export const EditJob = () => {
+  const jobData = {
+    id: 1,
+    internship: false,
+    title: 'Data Engineer 3',
+    company: 'BigData Spot',
+    description: 'yadda yadda',
+    link: 'https://www.bigdata.spot.com',
+    status: 'Applied',
+  } as JobRowData;
+
+  const contactData = {
+    name: 'MyFake Name',
+    email: 'myfake.name@fake.com',
+    phone_no: '555-555-5555',
+    company: 'FakeCompany',
+  } as ContactRowData;
+
+  const [jobTitle, setJobTitle] = useState<string>(jobData['title']);
+  const [isTitleError, setTitleError] = useState<boolean>(false);
+  const [companyName, setCompanyName] = useState<string>(jobData['company']);
+  const [isCompanyError, setCompanyError] = useState<boolean>(false);
+  const [jobDesc, setJobDesc] = useState<string>(jobData['description']);
+  const [isDescriptionError, setDescriptionError] = useState<boolean>(false);
+  const [jobURL, setJobURL] = useState<string>(jobData['link']);
+  const [isUrlError, setUrlError] = useState<boolean>(false);
+  const [isInternship, setIsInternship] = useState<boolean>(jobData['internship']);
+  const [jobStatus, setJobStatus] = useState<string>(jobData['status']);
+
+  const handleJobTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setJobTitle(event.target.value);
+    setTitleError(false);
+  };
+
+  const handleCompanyNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCompanyName(event.target.value);
+    setCompanyError(false);
+  };
+
+  const handleJobDescChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setJobDesc(event.target.value);
+    setDescriptionError(false);
+  };
+
+  const handleJobURLChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setJobURL(event.target.value);
+    setUrlError(false);
+  };
+
+  const handleJobStatusChange = (event: SelectChangeEvent) => {
+    setJobStatus(event.target.value);
+  };
+
+  const handleEditJobAndSkills = () => {
+    const editedJobData: JobRowData = {
+      id: 1,
+      internship: isInternship,
+      title: jobTitle,
+      company: companyName,
+      description: jobDesc,
+      link: jobURL,
+      status: jobStatus,
+    };
+    console.log(editedJobData);
+  };
+
+  return (
+    <Container maxWidth="lg">
+      <Paper elevation={10} style={{ padding: '16px', margin: '16px auto' }}>
+        <Stack spacing={2} justifyContent="center" alignItems="center">
+          <Typography component="h1">Edit Job Application</Typography>
+          <Box component="form" noValidate width="400px">
+            <Grid container spacing={2} alignItems="center" justifyContent="center">
+              <Grid item xs={12}>
+                <TextField
+                  id="jobtitle"
+                  label="Job Title"
+                  variant="standard"
+                  fullWidth
+                  required
+                  type="text"
+                  error={isTitleError}
+                  value={jobTitle}
+                  onChange={handleJobTitleChange}
+                />
+              </Grid>
+              {/** end of jobtitle item */}
+              <Grid item xs={12}>
+                <TextField
+                  id="companyname"
+                  label="Company Name"
+                  variant="standard"
+                  fullWidth
+                  required
+                  type="text"
+                  error={isCompanyError}
+                  value={companyName}
+                  onChange={handleCompanyNameChange}
+                />
+              </Grid>
+              {/** end of companyname item */}
+              <Grid item xs={12}>
+                <TextField
+                  id="jobdesc"
+                  label="Job Description"
+                  variant="standard"
+                  fullWidth
+                  required
+                  type="text"
+                  error={isDescriptionError}
+                  value={jobDesc}
+                  onChange={handleJobDescChange}
+                />
+              </Grid>
+              {/** end of jobdesc item */}
+              <Grid item xs={12}>
+                <TextField
+                  id="joburl"
+                  label="URL to Job Post"
+                  variant="standard"
+                  fullWidth
+                  required
+                  type="text"
+                  error={isUrlError}
+                  value={jobURL}
+                  onChange={handleJobURLChange}
+                />
+              </Grid>
+              {/** end of joburl item */}
+              <Grid item xs={12}>
+                <FormControlLabel
+                  control={<Checkbox checked={isInternship} onChange={() => setIsInternship(!isInternship)} />}
+                  label="This position is an internship"
+                />
+              </Grid>
+              {/** end of internship item */}
+              <Grid item xs={12} style={{ marginBottom: '24px' }}>
+                <FormControl fullWidth>
+                  <InputLabel id="status-label">Status</InputLabel>
+                  <Select
+                    labelId="status-label"
+                    id="status"
+                    label="Status"
+                    required
+                    fullWidth
+                    variant="standard"
+                    value={jobStatus}
+                    onChange={handleJobStatusChange}
+                  >
+                    <MenuItem value={'Applied'}>Applied</MenuItem>
+                    <MenuItem value={'Interview Scheduled'}>Interview Scheduled</MenuItem>
+                    <MenuItem value={'Decision Pending'}>Decision Pending</MenuItem>
+                    <MenuItem value={'Accepted'}>Accepted</MenuItem>
+                    <MenuItem value={'Rejected'}>Rejected</MenuItem>
+                  </Select>
+                </FormControl>
+              </Grid>
+              {/** end of status item */}
+              <Typography component="h1">Edit Skills</Typography>
+              {/** TODO - Need to grab values from Skills here */}
+              <Grid item xs={12} style={{ marginBottom: '48px' }}>
+                <Button color="primary" sx={{ borderRadius: 28 }} variant="contained">
+                  <Typography variant="body2">+Add Skill</Typography>
+                </Button>
+              </Grid>
+              {/** end of edit skills item */}
+              <Grid item xs={4}>
+                <Button variant="outlined">Cancel</Button>
+              </Grid>
+              <Grid item xs={4}>
+                <Button variant="contained" onClick={handleEditJobAndSkills}>
+                  Submit
+                </Button>
+              </Grid>
+              <Grid style={{ marginTop: '24px' }}>
+                <ContactsUpdate title="Edit Contact" route="/contacts/view/:id" contactData={contactData} />
+              </Grid>
+            </Grid>
+            {/** end of container */}
+          </Box>
+          {/** end of form */}
+        </Stack>
+      </Paper>
+    </Container>
+  );
+};
+
+type JobRowData = {
+  id: number;
+  internship: boolean;
+  title: string;
+  company: string;
+  description: string;
+  link: string;
+  status: string;
+};

--- a/client/src/pages/jobPages/index.ts
+++ b/client/src/pages/jobPages/index.ts
@@ -1,3 +1,4 @@
 export * from './CreateJob';
 export * from './Home';
 export * from './ViewJob';
+export * from './EditJob';


### PR DESCRIPTION
### What This PR Does
-------------
This is the second draft of the UI for the Edit Job page. 
1. Users can edit their job, skills, and contacts data all in one page.
2. Note: this PR does not include the most recent Add Skills feature as noted in PR: https://github.com/adam-osu/job-tracker/pull/39
3. ContactsUpdate.tsx now accepts a ContactRowData object to allow the modal to be pre-populated with contacts data (name, email, phone number and company)
![Capture](https://user-images.githubusercontent.com/19893639/168941563-86ee6ef6-a024-4ecd-ae5f-cac56c9b9555.JPG)
.