### PR TITLE
fix table links not being clickable

### DIFF
--- a/client/src/pages/jobPages/Home.tsx
+++ b/client/src/pages/jobPages/Home.tsx
@@ -99,8 +99,18 @@ const DataTable: React.FC<{ data: JobRowData[] }> = ({ data }): React.ReactEleme
                   </TableCell>
                   <TableCell align="right">{row.company}</TableCell>
                   <TableCell align="right">{row.status}</TableCell>
-                  <TableCell align="right">
-                    <a href={row.link}>{row.link}</a>
+                  <TableCell
+                    align="right"
+                    onClick={(e) => e.stopPropagation()}
+                    sx={{
+                      '&:hover': {
+                        cursor: 'default',
+                      },
+                    }}
+                  >
+                    <a href={row.link} target="_blank" rel="noreferrer">
+                      {row.link}
+                    </a>
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
I noticed that the job table links were not clickable because the parent's `onClick` was taking over and taking us to the view job page instead.  This PR should fix that