### PR TITLE
[BUGFIX] react-query login 401 bug

### DIFF
--- a/client/src/common/JobsQueryProvider.tsx
+++ b/client/src/common/JobsQueryProvider.tsx
@@ -4,6 +4,7 @@ import type { UseMutateFunction } from 'react-query';
 import { createJob, fetchAllJobs, updateJob } from '../repository';
 import { JobPageData } from '../types';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
 
 export interface CachedJobsContext {
   fetchAllJobsHasError: boolean;
@@ -54,6 +55,7 @@ export const JobsQueryProvider: React.FunctionComponent<{ children: React.ReactN
 export const CachedJobsProvider: React.FunctionComponent<{ children: React.ReactNode }> = ({ children }) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   // Queries
   const {
@@ -63,6 +65,10 @@ export const CachedJobsProvider: React.FunctionComponent<{ children: React.React
     data,
   } = useQuery<JobPageData[], Error>('jobsData', fetchAllJobs, {
     cacheTime: Infinity,
+    enabled: !!user,
+    retry: 5,
+    // This applies exponential backoff on retry attempts
+    retryDelay: (attempt) => Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000),
   });
 
   // Mutations


### PR DESCRIPTION
This PR fixes the bug where we get a 401 error on the jobData immediately after login.  Problem is that the query executes before the user is authenticated then doesn't retry after we log in.  This disables the query until we have a user logged in.

Also adds some other retry settings in case there are other situations that cause the query to fail