### PR TITLE
fix private route redirect bug

### DIFF
--- a/client/src/common/Routes.tsx
+++ b/client/src/common/Routes.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import type React from 'react';
 
 import { Login } from '../pages/Login';
@@ -9,101 +9,98 @@ import { CreateContact, ContactsHome, ContactsView, ContactsEdit } from '../page
 import { Skills } from '../pages/Skills';
 import { useAuth } from './AuthContext';
 
-export const PageRoutes = () => {
-  console.log('we got here');
-  return (
-    <Routes>
-      <Route
-        path="/"
-        element={
-          <PrivateRoute>
-            <Home />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/login"
-        element={
-          <PublicRoute>
-            <Login />
-          </PublicRoute>
-        }
-      />
-      <Route
-        path="/signup"
-        element={
-          <PublicRoute>
-            <Signup />
-          </PublicRoute>
-        }
-      />
-      <Route
-        path="/jobs/create"
-        element={
-          <PublicRoute>
-            <CreateJob />
-          </PublicRoute>
-        }
-      />
-      <Route
-        path="/jobs/view/:jobId"
-        element={
-          <PrivateRoute>
-            <ViewJob />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/jobs/edit/:jobId"
-        element={
-          <PrivateRoute>
-            <EditJob />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/contacts"
-        element={
-          <PrivateRoute>
-            <ContactsHome />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/contacts/create"
-        element={
-          <PrivateRoute>
-            <CreateContact />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/contacts/view/:id"
-        element={
-          <PrivateRoute>
-            <ContactsView />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/contacts/edit/:id"
-        element={
-          <PrivateRoute>
-            <ContactsEdit />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path="/skills"
-        element={
-          <PrivateRoute>
-            <Skills />
-          </PrivateRoute>
-        }
-      />
-    </Routes>
-  );
-};
+export const PageRoutes = () => (
+  <Routes>
+    <Route
+      path="/"
+      element={
+        <PrivateRoute>
+          <Home />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/login"
+      element={
+        <PublicRoute>
+          <Login />
+        </PublicRoute>
+      }
+    />
+    <Route
+      path="/signup"
+      element={
+        <PublicRoute>
+          <Signup />
+        </PublicRoute>
+      }
+    />
+    <Route
+      path="/jobs/create"
+      element={
+        <PublicRoute>
+          <CreateJob />
+        </PublicRoute>
+      }
+    />
+    <Route
+      path="/jobs/view/:jobId"
+      element={
+        <PrivateRoute>
+          <ViewJob />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/jobs/edit/:jobId"
+      element={
+        <PrivateRoute>
+          <EditJob />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/contacts"
+      element={
+        <PrivateRoute>
+          <ContactsHome />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/contacts/create"
+      element={
+        <PrivateRoute>
+          <CreateContact />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/contacts/view/:id"
+      element={
+        <PrivateRoute>
+          <ContactsView />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/contacts/edit/:id"
+      element={
+        <PrivateRoute>
+          <ContactsEdit />
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/skills"
+      element={
+        <PrivateRoute>
+          <Skills />
+        </PrivateRoute>
+      }
+    />
+  </Routes>
+);
 
 export const PublicRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return <>{children}</>;
@@ -111,10 +108,11 @@ export const PublicRoute: React.FC<{ children: React.ReactNode }> = ({ children 
 
 export const PrivateRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
+  const location = useLocation();
 
   if (user) {
     return <>{children}</>;
   }
 
-  return <Navigate to="/login" />;
+  return <Navigate to="/login" state={{ from: location.pathname }} />;
 };

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { Avatar, Button, Container, Link, Paper, Stack, TextField, Typography } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useAuth } from '../common/AuthContext';
-import { useNavigate, Navigate } from 'react-router-dom';
+import { useNavigate, useLocation, Navigate } from 'react-router-dom';
+import { doesObjectContainKey } from '../types/typeGuards';
 
 const emailPattern = new RegExp(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/);
 
@@ -11,6 +12,7 @@ export const Login = () => {
   const [password, setPassword] = useState<string>('');
   const [isError, setIsError] = useState<boolean>(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const { user, loginUser } = useAuth();
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,6 +37,9 @@ export const Login = () => {
   };
 
   if (user) {
+    if (doesObjectContainKey(location.state, 'from') && typeof location.state.from === 'string') {
+      return <Navigate to={location.state.from} />;
+    }
     return <Navigate to="/" />;
   }
 

--- a/client/src/repository/index.ts
+++ b/client/src/repository/index.ts
@@ -69,7 +69,6 @@ export const createJob = async (jobData: Partial<JobNewData>) => {
 };
 
 export const fetchAllJobs = async () => {
-  console.log('fetching');
   const response = await apiClient.get<JobPageData[]>('/jobs');
   return response.data;
 };
@@ -85,7 +84,7 @@ export const fetchJob = async (jobId: string) => {
 
 export const deleteJob = async (jobId: string) => {
   return apiClient.delete(`/jobs/${jobId}`);
-}
+};
 
 export const fetchSkillsByUser = async () => {
   return apiClient.get('/skills');

--- a/client/src/types/typeGuards.ts
+++ b/client/src/types/typeGuards.ts
@@ -1,0 +1,2 @@
+export const doesObjectContainKey = <T extends string>(obj: unknown, key: T): obj is Partial<Record<T, string>> =>
+  typeof obj === 'object' && obj !== null && key in obj;


### PR DESCRIPTION
Bug cause:

1. `PrivateRoute` component does not see a user when the page first loads so we redirect to '/login'
2. login page eventually receives the `user` object.
3. login page redirects us to home

Fix:
When a private route fails to find the user, attach the requested url to the location state, then redirect to the login page.  When the user logs in, or the user object is eventually fetched, the `Login` component sends us to the pathname passed in the state if one exists, else defaulting to the homepage 